### PR TITLE
Feature/upload icps

### DIFF
--- a/bioseeker.py
+++ b/bioseeker.py
@@ -7,9 +7,18 @@ from tools.assembler import assembler
 from tools.delete import delete_csv_files
 from utils.intro import intro_message
 from os import getcwd
+from upload_icps import upload_icps
+
 
 def main():
     intro_message()
+    
+    # Ask the user to upload an ICP file
+    file_path = input("Please enter the path of the ICP file to upload: ")
+    upload_message = upload_icps(file_path)
+    print(upload_message)
+
+    
     #   Generating list of files on current working directory
     BASE_PATH = getcwd()
     files = lf.list_of_files(BASE_PATH)

--- a/bioseeker.py
+++ b/bioseeker.py
@@ -7,7 +7,7 @@ from tools.assembler import assembler
 from tools.delete import delete_csv_files
 from utils.intro import intro_message
 from os import getcwd
-from upload_icps import upload_icps
+from tools.upload_icps import upload_icps
 
 
 def main():

--- a/tools/upload_icps.py
+++ b/tools/upload_icps.py
@@ -1,0 +1,32 @@
+# upload_icps.py
+import pandas as pd
+import os
+
+def upload_icps(file_path: str):
+    """Function to upload ICPs from a CSV file and store it in the appropriate directory.
+
+    Args:
+        file_path (str): Path of the file to upload.
+
+    Returns:
+        str: Confirmation message.
+    """
+    if not os.path.exists(file_path) or not file_path.endswith('.csv'):
+        return "The file does not exist or is not a valid CSV file."
+
+    try:
+        df = pd.read_csv(file_path)
+        
+        # Check if the file contains the necessary columns (adapt as needed)
+        required_columns = ['Codon', 'ConservationRate']  # Example of expected columns
+        if not all(col in df.columns for col in required_columns):
+            return "The CSV file does not contain all required columns."
+
+        # Save the file to a specific directory
+        output_dir = 'user_uploaded_icps'
+        os.makedirs(output_dir, exist_ok=True)
+        df.to_csv(os.path.join(output_dir, 'uploaded_icps.csv'), index=False)
+
+        return "ICPs file uploaded successfully."
+    except Exception as e:
+        return f"Error while uploading the ICPs file: {str(e)}"


### PR DESCRIPTION
### Description
This pull request adds a new component that allows users to upload their own predefined InterCodon Pairs (ICPs) from a CSV file. 

### Changes Made
- Created `upload_icps.py` to handle the uploading of ICPs.
- Integrated the upload functionality into `bioseeker.py`.

### How to Test
1. Run the `bioseeker.py` script.
2. When prompted, provide the path to a CSV file containing the ICPs.
3. Verify that the ICPs are uploaded successfully.

### Issue Reference
Fixes #9
